### PR TITLE
Fix SEO alt tag property

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -44,7 +44,7 @@ export default function Homepage({ language }) {
         <meta property="og:title" content={seoData.title} />
         <meta property="og:description" content={seoData.description} />
         <meta property="og:image" content={seoData.structuredData.image} />
-        <meta property="og:image:alt" content={seoData.imageAlt} />
+        <meta property="og:image:alt" content={seoData.imgAlt} />
         <meta property="og:image:width" content="452" />
         <meta property="og:image:height" content="452" />{' '}
         <meta property="og:url" content="https://sitedesign.no" />


### PR DESCRIPTION
## Summary
- fix OG image alt text by using `imgAlt`

## Testing
- `npm run lint` *(fails: `next` not found)*